### PR TITLE
Ignore pids when matching replay arguments

### DIFF
--- a/lib/walkman_server.ex
+++ b/lib/walkman_server.ex
@@ -95,13 +95,12 @@ defmodule WalkmanServer do
     filename(test_id) |> File.write!(:erlang.term_to_binary(Enum.reverse(tests)), [:write])
   end
 
-  defp args_match?(args, replay_args) do
-    normalize_pids(args) == normalize_pids(replay_args)
+  defp args_match?({m, f, a}, {m2, f2, a2}) do
+    {m, f, normalize_pids(a)} == {m, f, normalize_pids(a2)}
   end
 
   defp normalize_pids(args) do
-    Tuple.to_list(args)
-    |> Enum.map(fn
+    Enum.map(args, fn
       pid when is_pid(pid) -> :pid
       other -> other
     end)

--- a/lib/walkman_server.ex
+++ b/lib/walkman_server.ex
@@ -42,7 +42,7 @@ defmodule WalkmanServer do
         # only match on first test, then discard it to preserve order
         case s.tests do
           [] ->
-            raise "there are no more calls left to replay"
+            raise "there are no more replays left (all replays have been used up)"
 
           [{replay_args, value} | tests] ->
             if args_match?(args, replay_args) do


### PR DESCRIPTION
Pids will never be predictable, so it's practically impossible to
construct a test that relies on pids being the same between test runs.
Better to just ignore them altogether.