### PR TITLE
Fix bug on use_tape macro

### DIFF
--- a/lib/walkman.ex
+++ b/lib/walkman.ex
@@ -130,6 +130,7 @@ defmodule Walkman do
       rescue
         e in RuntimeError ->
           :ok = GenServer.call(pid, :cancel)
+          raise e
       else
         _ ->
           :ok = GenServer.call(pid, :finish)

--- a/test/walkman_test.exs
+++ b/test/walkman_test.exs
@@ -46,4 +46,12 @@ defmodule WalkmanTest do
 
     refute File.exists?("test/fixtures/walkman/no_fixture")
   end
+
+  test "does not fail silently on RuntimeError" do
+    assert_raise(RuntimeError, fn ->
+      Walkman.use_tape "run_time_error" do
+        raise "Error"
+      end
+    end)
+  end
 end


### PR DESCRIPTION
The macro was capturing the exceptions and causing a failing test to
pass when the exception was happening before the asserts statements.