### PR TITLE
Fix registry error

### DIFF
--- a/lib/walkman.ex
+++ b/lib/walkman.ex
@@ -128,7 +128,7 @@ defmodule Walkman do
       try do
         unquote(block)
       rescue
-        e in RuntimeError ->
+        e ->
           :ok = GenServer.call(pid, :cancel)
           raise e
       else

--- a/lib/walkman/tape.ex
+++ b/lib/walkman/tape.ex
@@ -35,11 +35,11 @@ defmodule Walkman.Tape do
   end
 
   defp register_tape(true, _test_pid) do
-    Registry.register(Walkman.TapeRegistry, :global, nil)
+    {:ok, _pid} = Registry.register(Walkman.TapeRegistry, :global, nil)
   end
 
   defp register_tape(false, test_pid) when is_pid(test_pid) do
-    Registry.register(Walkman.TapeRegistry, test_pid, nil)
+    {:ok, _pid} = Registry.register(Walkman.TapeRegistry, test_pid, nil)
   end
 
   def init(options) do


### PR DESCRIPTION
The tape registry was not handling the cases when there was an attempt to register it twice.